### PR TITLE
Make launch_hw param reconfigurable.

### DIFF
--- a/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
+++ b/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
@@ -115,8 +115,9 @@ VelodyneStatus VelodyneHwInterface::init_http_client()
       }
       return Status::OK;
     } catch (const std::exception & ex) {
-      std::cerr << "Error initializing lidar: " << ex.what() << std::endl;
-      std::cerr << "Retrying after 5 seconds..." << std::endl;
+      RCLCPP_INFO_ONCE(
+        *parent_node_logger_, "Cannot connect to lidar because of: %s. Will keep trying...",
+        ex.what());
       std::this_thread::sleep_for(std::chrono::seconds(5));
     }
   }

--- a/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
+++ b/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
@@ -107,16 +107,19 @@ Status VelodyneHwInterface::get_sensor_configuration(SensorConfigurationBase & s
 
 VelodyneStatus VelodyneHwInterface::init_http_client()
 {
-  try {
-    http_client_driver_->init_client(sensor_configuration_->sensor_ip, 80);
-    if (!http_client_driver_->client()->isOpen()) {
-      http_client_driver_->client()->open();
+  while (true) {
+    try {
+      http_client_driver_->init_client(sensor_configuration_->sensor_ip, 80);
+      if (!http_client_driver_->client()->isOpen()) {
+        http_client_driver_->client()->open();
+      }
+      return Status::OK;
+    } catch (const std::exception & ex) {
+      std::cerr << "Error initializing lidar: " << ex.what() << std::endl;
+      std::cerr << "Retrying after 5 seconds..." << std::endl;
+      std::this_thread::sleep_for(std::chrono::seconds(5));
     }
-  } catch (const std::exception & ex) {
-    VelodyneStatus status = Status::HTTP_CONNECTION_ERROR;
-    return status;
   }
-  return Status::OK;
 }
 
 void VelodyneHwInterface::string_callback(const std::string & str)

--- a/nebula_ros/CMakeLists.txt
+++ b/nebula_ros/CMakeLists.txt
@@ -3,7 +3,7 @@ project(nebula_ros)
 
 # Default to C++17
 if (NOT CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_CXX_STANDARD 20)
 endif ()
 
 if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/nebula_ros/include/nebula_ros/common/mt_queue.hpp
+++ b/nebula_ros/include/nebula_ros/common/mt_queue.hpp
@@ -61,4 +61,17 @@ public:
 
     return return_value;
   }
+
+  std::pair<T, bool> pop(std::chrono::milliseconds timeout)
+  {
+    std::unique_lock<std::mutex> lock(this->mutex_);
+    if (!this->cv_not_empty_.wait_for(lock, timeout, [this] { return !this->queue_.empty(); })) {
+      return std::make_pair(T(), false);
+    }
+    T return_value(std::move(this->queue_.back()));
+    this->queue_.pop_back();
+    this->cv_not_full_.notify_all();
+
+    return std::make_pair(std::move(return_value), true);
+  }
 };

--- a/nebula_ros/include/nebula_ros/common/mt_queue.hpp
+++ b/nebula_ros/include/nebula_ros/common/mt_queue.hpp
@@ -46,7 +46,7 @@ public:
   void push(T && value)
   {
     std::unique_lock<std::mutex> lock(this->mutex_);
-    this->cv_not_full_.wait(lock, [=] { return this->queue_.size() < this->capacity_; });
+    this->cv_not_full_.wait(lock, [this] { return this->queue_.size() < this->capacity_; });
     queue_.push_front(std::move(value));
     this->cv_not_empty_.notify_all();
   }
@@ -54,7 +54,7 @@ public:
   T pop()
   {
     std::unique_lock<std::mutex> lock(this->mutex_);
-    this->cv_not_empty_.wait(lock, [=] { return !this->queue_.empty(); });
+    this->cv_not_empty_.wait(lock, [this] { return !this->queue_.empty(); });
     T return_value(std::move(this->queue_.back()));
     this->queue_.pop_back();
     this->cv_not_full_.notify_all();

--- a/nebula_ros/include/nebula_ros/velodyne/velodyne_ros_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/velodyne/velodyne_ros_wrapper.hpp
@@ -69,6 +69,22 @@ private:
 
   Status declare_and_get_sensor_config_params();
 
+  void reconfigure_hw_interface();
+
+  void create_packet_subscriber();
+  void reset_packet_subscriber();
+
+  // HW interface management
+  void bringup_hw(bool);
+  void cleanup_on_hw_reconfigure();
+  void setup_on_hw_reconfigure();
+
+  // Decoder thread management
+  void configure_decoder_wrapper_thread();
+  void start_decoder_thread();
+  void stop_decoder_thread();
+  void exit_decoder_thread();
+
   /// @brief rclcpp parameter callback
   /// @param parameters Received parameters
   /// @return SetParametersResult
@@ -90,10 +106,19 @@ private:
   rclcpp::Subscription<velodyne_msgs::msg::VelodyneScan>::SharedPtr packets_sub_{};
 
   bool launch_hw_;
+  bool use_udp_only_;
+
+  std::mutex decoder_thread_mutex_;
+  std::condition_variable decoder_thread_cv_;
+  bool decoder_thread_running_ = false;
+  bool exit_decoder_thread_ = false;
+  bool restart_hw_ = false;
+  bool restart_packet_subscriber_ = false;
 
   std::optional<VelodyneHwInterfaceWrapper> hw_interface_wrapper_;
   std::optional<VelodyneHwMonitorWrapper> hw_monitor_wrapper_;
   std::optional<VelodyneDecoderWrapper> decoder_wrapper_;
+  rclcpp::TimerBase::SharedPtr hw_reconfigure_timer_;
 
   std::mutex mtx_config_;
 

--- a/nebula_ros/include/nebula_ros/velodyne/velodyne_ros_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/velodyne/velodyne_ros_wrapper.hpp
@@ -80,10 +80,9 @@ private:
   void setup_on_hw_reconfigure();
 
   // Decoder thread management
-  void configure_decoder_wrapper_thread();
-  void start_decoder_thread();
-  void stop_decoder_thread();
-  void exit_decoder_thread();
+  void decoder_wrapper_thread(std::stop_token stoken);
+  void set_decoder_wrapper();
+  void stop_decoder_thread() { decoder_thread_.request_stop(); }
 
   /// @brief rclcpp parameter callback
   /// @param parameters Received parameters
@@ -101,17 +100,13 @@ private:
   /// @brief Stores received packets that have not been processed yet by the decoder thread
   MtQueue<std::unique_ptr<nebula_msgs::msg::NebulaPacket>> packet_queue_;
   /// @brief Thread to isolate decoding from receiving
-  std::thread decoder_thread_;
+  std::jthread decoder_thread_;
 
   rclcpp::Subscription<velodyne_msgs::msg::VelodyneScan>::SharedPtr packets_sub_{};
 
   bool launch_hw_;
   bool use_udp_only_;
 
-  std::mutex decoder_thread_mutex_;
-  std::condition_variable decoder_thread_cv_;
-  bool decoder_thread_running_ = false;
-  bool exit_decoder_thread_ = false;
   bool restart_hw_ = false;
   bool restart_packet_subscriber_ = false;
 

--- a/nebula_ros/include/nebula_ros/velodyne/velodyne_ros_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/velodyne/velodyne_ros_wrapper.hpp
@@ -77,7 +77,7 @@ private:
   // HW interface management
   void bringup_hw(bool);
   void cleanup_on_hw_reconfigure();
-  void setup_on_hw_reconfigure();
+  void setup_decoder();
 
   // Decoder thread management
   void decoder_wrapper_thread(std::stop_token stoken);

--- a/nebula_ros/src/velodyne/decoder_wrapper.cpp
+++ b/nebula_ros/src/velodyne/decoder_wrapper.cpp
@@ -31,8 +31,12 @@ VelodyneDecoderWrapper::VelodyneDecoderWrapper(
       "VelodyneDecoderWrapper cannot be instantiated without a valid config!");
   }
 
-  calibration_file_path_ =
-    parent_node->declare_parameter<std::string>("calibration_file", param_read_write());
+  if (parent_node->has_parameter("calibration_file")) {
+    calibration_file_path_ = parent_node->get_parameter("calibration_file").as_string();
+  } else {
+    calibration_file_path_ =
+      parent_node->declare_parameter<std::string>("calibration_file", param_read_write());
+  }
   auto calibration_result = get_calibration_data(calibration_file_path_);
 
   if (!calibration_result.has_value()) {

--- a/nebula_ros/src/velodyne/hw_interface_wrapper.cpp
+++ b/nebula_ros/src/velodyne/hw_interface_wrapper.cpp
@@ -17,8 +17,11 @@ VelodyneHwInterfaceWrapper::VelodyneHwInterfaceWrapper(
   status_(Status::NOT_INITIALIZED),
   use_udp_only_(use_udp_only)
 {
-  setup_sensor_ = parent_node->declare_parameter<bool>("setup_sensor", param_read_only());
-
+  if (parent_node->has_parameter("setup_sensor")) {
+    setup_sensor_ = parent_node->get_parameter("setup_sensor").as_bool();
+  } else {
+    setup_sensor_ = parent_node->declare_parameter<bool>("setup_sensor", param_read_only());
+  }
   hw_interface_->set_logger(
     std::make_shared<rclcpp::Logger>(parent_node->get_logger().get_child("HwInterface")));
   status_ = hw_interface_->initialize_sensor_configuration(config);

--- a/nebula_ros/src/velodyne/hw_monitor_wrapper.cpp
+++ b/nebula_ros/src/velodyne/hw_monitor_wrapper.cpp
@@ -23,9 +23,17 @@ VelodyneHwMonitorWrapper::VelodyneHwMonitorWrapper(
   parent_node_(parent_node),
   sensor_configuration_(config)
 {
-  diag_span_ = parent_node->declare_parameter<uint16_t>("diag_span", param_read_only());
-  show_advanced_diagnostics_ =
-    parent_node->declare_parameter<bool>("advanced_diagnostics", param_read_only());
+  if (parent_node->has_parameter("diag_span")) {
+    diag_span_ = parent_node->get_parameter("diag_span").as_int();
+  } else {
+    diag_span_ = parent_node->declare_parameter<uint16_t>("diag_span", param_read_only());
+  }
+  if (parent_node->has_parameter("advanced_diagnostics")) {
+    show_advanced_diagnostics_ = parent_node->get_parameter("advanced_diagnostics").as_bool();
+  } else {
+    show_advanced_diagnostics_ =
+      parent_node->declare_parameter<bool>("advanced_diagnostics", param_read_only());
+  }
 
   std::cout << "Get model name and serial." << std::endl;
   auto str = hw_interface_->get_snapshot();

--- a/nebula_ros/src/velodyne/velodyne_ros_wrapper.cpp
+++ b/nebula_ros/src/velodyne/velodyne_ros_wrapper.cpp
@@ -4,6 +4,8 @@
 
 #include <nebula_common/util/string_conversions.hpp>
 
+#include <pthread.h>  // debug only
+
 #include <algorithm>
 #include <cstdio>
 #include <memory>
@@ -26,7 +28,7 @@ VelodyneRosWrapper::VelodyneRosWrapper(const rclcpp::NodeOptions & options)
   hw_reconfigure_timer_(this->create_wall_timer(
     std::chrono::seconds(1), std::bind(&VelodyneRosWrapper::reconfigure_hw_interface, this)))
 {
-  hw_reconfigure_timer_->cancel();  // Cancel the timer until the HW interface is initialized
+  hw_reconfigure_timer_->cancel();
   setvbuf(stdout, NULL, _IONBF, BUFSIZ);
 
   wrapper_status_ = declare_and_get_sensor_config_params();
@@ -53,8 +55,7 @@ VelodyneRosWrapper::VelodyneRosWrapper(const rclcpp::NodeOptions & options)
     create_packet_subscriber();
   }
 
-  set_decoder_wrapper();
-  decoder_thread_ = std::jthread(&VelodyneRosWrapper::decoder_wrapper_thread, this);
+  setup_decoder();
 
   // Register parameter callback after all params have been declared. Otherwise it would be called
   // once for each declaration
@@ -66,14 +67,14 @@ void VelodyneRosWrapper::reconfigure_hw_interface()
 {
   if (restart_hw_) {
     bringup_hw(use_udp_only_);
-    setup_on_hw_reconfigure();
+    setup_decoder();
     restart_hw_ = false;
     hw_reconfigure_timer_->cancel();
   }
 
   if (restart_packet_subscriber_) {
     create_packet_subscriber();
-    setup_on_hw_reconfigure();
+    setup_decoder();
     restart_packet_subscriber_ = false;
     hw_reconfigure_timer_->cancel();
   }
@@ -91,6 +92,10 @@ void VelodyneRosWrapper::create_packet_subscriber()
 
 void VelodyneRosWrapper::set_decoder_wrapper()
 {
+  // If there's an existing decoder wrapper, reset it
+  if (decoder_wrapper_) {
+    decoder_wrapper_.reset();
+  }
   decoder_wrapper_.emplace(
     this, hw_interface_wrapper_ ? hw_interface_wrapper_->hw_interface() : nullptr, sensor_cfg_ptr_);
 }
@@ -100,8 +105,14 @@ void VelodyneRosWrapper::decoder_wrapper_thread(std::stop_token stoken)
   RCLCPP_DEBUG(get_logger(), "Starting stream");
 
   while (!stoken.stop_requested()) {
-    decoder_wrapper_->process_cloud_packet(packet_queue_.pop());
+    auto [packet, valid] = packet_queue_.pop(std::chrono::milliseconds(100));
+    if (valid) {
+      decoder_wrapper_->process_cloud_packet(std::move(packet));
+    } else {
+      continue;
+    }
   }
+  RCLCPP_INFO(get_logger(), "Gracefully stopped decoder thread");
 }
 
 void VelodyneRosWrapper::bringup_hw(bool use_udp_only)
@@ -231,7 +242,13 @@ Status VelodyneRosWrapper::stream_start()
 
 void VelodyneRosWrapper::cleanup_on_hw_reconfigure()
 {
-  stop_decoder_thread();
+  while (true) {
+    if (decoder_thread_.joinable()) {
+      stop_decoder_thread();
+      break;
+    }
+  }
+  decoder_thread_.join();
   if (hw_interface_wrapper_) {
     hw_interface_wrapper_.reset();
   }
@@ -240,10 +257,12 @@ void VelodyneRosWrapper::cleanup_on_hw_reconfigure()
   }
 }
 
-void VelodyneRosWrapper::setup_on_hw_reconfigure()
+void VelodyneRosWrapper::setup_decoder()
 {
   set_decoder_wrapper();
   decoder_thread_ = std::jthread(&VelodyneRosWrapper::decoder_wrapper_thread, this);
+  // Set the thread name
+  pthread_setname_np(decoder_thread_.native_handle(), "VelDecThread");  // debug only
 }
 
 void VelodyneRosWrapper::reset_packet_subscriber()

--- a/nebula_ros/src/velodyne/velodyne_ros_wrapper.cpp
+++ b/nebula_ros/src/velodyne/velodyne_ros_wrapper.cpp
@@ -66,12 +66,14 @@ void VelodyneRosWrapper::reconfigure_hw_interface()
     bringup_hw(use_udp_only_);
     setup_on_hw_reconfigure();
     restart_hw_ = false;
+    hw_reconfigure_timer_->cancel();
   }
 
   if (restart_packet_subscriber_) {
     create_packet_subscriber();
     setup_on_hw_reconfigure();
     restart_packet_subscriber_ = false;
+    hw_reconfigure_timer_->cancel();
   }
 }
 
@@ -313,6 +315,7 @@ rcl_interfaces::msg::SetParametersResult VelodyneRosWrapper::on_parameter_change
     reset_packet_subscriber();
     cleanup_on_hw_reconfigure();
     restart_hw_ = true;
+    hw_reconfigure_timer_->reset();
   }
 
   if (got_any && !launch_hw_ && hw_interface_wrapper_) {
@@ -320,6 +323,7 @@ rcl_interfaces::msg::SetParametersResult VelodyneRosWrapper::on_parameter_change
     cleanup_on_hw_reconfigure();
     reset_packet_subscriber();
     restart_packet_subscriber_ = true;
+    hw_reconfigure_timer_->reset();
   }
 
   // Currently, HW interface and monitor wrappers have only read-only parameters, so their update


### PR DESCRIPTION
### The problem:
`nebula_ros` doesn't support dynamic enabling/disabling of hw driver at runtime because the `launch_hw` parameter is read-only.

### This PR:
A WIP solution attempt to make the parameter dynamically reconfigurable and setup necessary hardware interfaces when the `launch_hw` parameter is set dynamically. I have tried to ensure the threading part is handled as carefully as possible, but it would be great if I can get some feedback on the same

### What has been tested so far:
- `ros2 param set <nebula_driver_node_name> launch_hw true` successfully returns: `Set parameter successful`.
- The runtime behavior remains the same with these changes as compared to the behavior before these changes i.e.,
  - This warning is continuously printed `Missed pointcloud output deadline` when `launch_hw` parameter is `false` (statically or dynamically set). This is because in this configuration, the driver is expecting some other source to publish on `/velodyne/packets` topic. When the parameter was read-only, this was the same behavior too.
  - When `launch_hw` is set to true (statically or dynamically) _without_ a physical lidar connected to the device, the lidar driver crashes with this exception `Could not initialize HTTP client: Http Connection Error`

### To test:
- Connect a real velodyne lidar and see if the node doesn't crash
- Replicate similar changes for hesai and other wrappers
- Create an upstream PR
